### PR TITLE
[fix]: #148 パラメータ処理のロジック修正

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -4,7 +4,7 @@ CommandHandler::CommandHandler(Server &server) : _server(server) {}
 CommandHandler::~CommandHandler() {}
 
 void CommandHandler::PASS(User &user) {
-  if (this->_params.at(0).empty()) {
+  if (this->_params.size() == 0) {
     this->_server.sendReply(user.getFd(),
                             Replies::ERR_NEEDMOREPARAMS(this->_command));
     return;
@@ -151,7 +151,7 @@ bool CommandHandler::isReservedNick(const std::string &nick) {
 
 void CommandHandler::NICK(User &user) {
   // ok
-  if (this->_params.at(0).empty()) {
+  if (this->_params.size() == 0) {
     this->_server.sendReply(user.getFd(), Replies::ERR_NONICKNAMEGIVEN());
     return;
   }
@@ -227,7 +227,7 @@ void CommandHandler::OPER(User &user) {
 }
 
 void CommandHandler::MOTD(User &user) {
-  if (!this->_params.at(0).empty()) {
+  if (!(this->_params.size() == 0)) {
     if (this->_params.at(0) != this->_server.getServerName()) {
       this->_server.sendReply(user.getFd(),
                               Replies::ERR_NOSUCHSERVER(this->_params.at(0)));
@@ -240,7 +240,7 @@ void CommandHandler::MOTD(User &user) {
 }
 
 void CommandHandler::LUSERS(User &user) {
-  if (!this->_params.at(0).empty()) {
+  if (!(this->_params.size() == 0)) {
     if (this->_params.at(0) != this->_server.getServerName() ||
         this->_params.at(1) != this->_server.getServerName()) {
       this->_server.sendReply(user.getFd(),
@@ -265,7 +265,7 @@ void CommandHandler::LUSERS(User &user) {
 }
 
 void CommandHandler::VERSION(User &user) {
-  if (!this->_params.at(0).empty()) {
+  if (!(this->_params.size() == 0)) {
     if (this->_params.at(0) != this->_server.getServerName()) {
       this->_server.sendReply(user.getFd(),
                               Replies::ERR_NOSUCHSERVER(this->_params.at(0)));
@@ -283,7 +283,7 @@ void CommandHandler::LINKS(User &user) {
 }
 
 void CommandHandler::TIME(User &user) {
-  if (!this->_params.at(0).empty()) {
+  if (!(this->_params.size() == 0)) {
     if (this->_params.at(0) != this->_server.getServerName()) {
       this->_server.sendReply(user.getFd(),
                               Replies::ERR_NOSUCHSERVER(this->_params.at(0)));
@@ -315,7 +315,7 @@ void CommandHandler::CONNECT(User &user) {
 }
 
 void CommandHandler::TRACE(User &user) {
-  if (!this->_params.at(0).empty()) {
+  if (!(this->_params.size() == 0)) {
     this->_server.sendReply(user.getFd(),
                             Replies::ERR_NOSUCHSERVER(this->_params.at(0)));
   } else {
@@ -325,7 +325,7 @@ void CommandHandler::TRACE(User &user) {
 }
 
 void CommandHandler::ADMIN(User &user) {
-  if (!this->_params.at(0).empty()) {
+  if (!(this->_params.size() == 0)) {
     if (this->_params.at(0) != this->_server.getServerName()) {
       this->_server.sendReply(user.getFd(),
                               Replies::ERR_NOSUCHSERVER(this->_params.at(0)));
@@ -341,7 +341,7 @@ void CommandHandler::ADMIN(User &user) {
 }
 
 void CommandHandler::INFO(User &user) {
-  if (!this->_params.at(0).empty()) {
+  if (!(this->_params.size() == 0)) {
     if (this->_params.at(0) != this->_server.getServerName()) {
       this->_server.sendReply(user.getFd(),
                               Replies::ERR_NOSUCHSERVER(this->_params.at(0)));

--- a/src/CommandHandler_Join.cpp
+++ b/src/CommandHandler_Join.cpp
@@ -19,7 +19,7 @@ void CommandHandler::JOIN(User &user) {
   std::vector<std::string> keys;
   unsigned int userStatus = Channel::Normal;
 
-  if (this->_params.at(0).empty()) {
+  if (this->_params.size() == 0) {
     this->_server.sendReply(user.getFd(),
                             Replies::ERR_NEEDMOREPARAMS(this->_command));
   }

--- a/src/CommandHandler_Part.cpp
+++ b/src/CommandHandler_Part.cpp
@@ -3,7 +3,7 @@
 void CommandHandler::PART(User &user) {
   std::vector<std::string> channelNames;
 
-  if (this->_params.at(0).empty()) {
+  if (this->_params.size() == 0) {
     this->_server.sendReply(user.getFd(),
                             Replies::ERR_NEEDMOREPARAMS(this->_command));
     return;

--- a/src/CommandHandler_parseMessage.cpp
+++ b/src/CommandHandler_parseMessage.cpp
@@ -35,7 +35,9 @@ void CommandHandler::extractParam(std::istringstream &iss) {
   std::string param;
 
   iss >> param;
-  this->_params.push_back(param);
+  if (!param.empty()) {
+    this->_params.push_back(param);
+  }
   if (iss.bad()) {
     throw std::runtime_error(
         "A critical error occurred while extracting param.");


### PR DESCRIPTION
コマンド処理において、パラメータが空の場合に正しく処理されない問題を修正しました。特に、パラメータの存在チェックを行う際に`.empty()`メソッドの使用から`size()`メソッドを用いたチェックに変更し、より直接的にパラメータの有無を判断するようにしました。

また、パラメータ抽出時に空文字列をパラメータリストに追加しないように修正し、コマンド処理において期待される振る舞いを正確に反映させることを確保しました。

この修正により、`PASS`, `NICK`, `MOTD`, `LUSERS`, `VERSION`, `TIME`, `CONNECT`, `TRACE`, `ADMIN`, `INFO`, `JOIN`, および `PART` コマンドを含む複数のコマンド処理ロジックが、パラメータの有無をより正確に判断し、適切に処理を行えるようになります。

[notes]

close #148