### PR TITLE
[fix]: #150 コマンド処理の条件分岐の誤りを修正

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -278,8 +278,13 @@ void CommandHandler::VERSION(User &user) {
                                                SERVER_VERSION_COMMENT));
 }
 void CommandHandler::LINKS(User &user) {
-  this->_server.sendReply(user.getFd(),
-                          Replies::ERR_NOSUCHSERVER(this->_params.at(0)));
+  if (this->_params.size() == 0) {
+    this->_server.sendReply(user.getFd(),
+                            Replies::ERR_NOSUCHSERVER(this->_server.getServerName()));
+  } else {
+    this->_server.sendReply(user.getFd(),
+                            Replies::ERR_NOSUCHSERVER(this->_params.at(0)));
+  }
 }
 
 void CommandHandler::TIME(User &user) {

--- a/src/Replies.cpp
+++ b/src/Replies.cpp
@@ -322,7 +322,7 @@ const std::string Replies::RPL_TIME(const std::string &serverName,
 // 402
 const std::string Replies::ERR_NOSUCHSERVER(const std::string &serverName) {
   std::string message;
-  message += "402";
+  message += "402 ";
   message += serverName;
   message += " :No such server";
   message += "\r\n";


### PR DESCRIPTION
`LINKS`コマンドの処理において、パラメータが存在しない場合の挙動が正しくなかった問題を修正しました。パラメータがない場合には、サーバー自身の名前を使用してエラーメッセージを返すように変更しました。また、`Replies.cpp`における`ERR_NOSUCHSERVER`メッセージのフォーマットが正しくなかったため、これも修正しました。

具体的には以下の変更を行いました：
- `CommandHandler.cpp`にて、`LINKS`コマンド処理時にパラメータの有無を確認し、適切に処理を分岐するように修正。
- パラメータが存在しない場合には、デフォルトでサーバー自身の名前を用いて`ERR_NOSUCHSERVER`を返すように変更。
- `Replies.cpp`における`ERR_NOSUCHSERVER`メッセージ生成時のフォーマットを正しいものに修正。

これにより、`LINKS`コマンドの挙動がRFCに準拠し、より直感的になりました。

[notes]

close #150