### PR TITLE
[feat]: #152 LUSERSコマンドの追加

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -240,11 +240,17 @@ void CommandHandler::MOTD(User &user) {
 }
 
 void CommandHandler::LUSERS(User &user) {
-  if (!(this->_params.size() == 0)) {
-    if (this->_params.at(0) != this->_server.getServerName() ||
-        this->_params.at(1) != this->_server.getServerName()) {
+  if (1 <= this->_params.size()) {
+    if (this->_params.at(0) != this->_server.getServerName()) {
       this->_server.sendReply(user.getFd(),
                               Replies::ERR_NOSUCHSERVER(this->_params.at(0)));
+      return;
+    }
+  }
+  if (2 <= this->_params.size()) {
+    if (this->_params.at(1) != this->_server.getServerName()) {
+      this->_server.sendReply(user.getFd(),
+                              Replies::ERR_NOSUCHSERVER(this->_params.at(1)));
       return;
     }
   }


### PR DESCRIPTION
LUSERSコマンドとERR_NOSUCHSERVERレスポンスの処理を改善しました。LUSERSコマンドにおいて、パラメータが1つまたは2つ指定された場合の挙動をRFCに準拠するように修正しました。また、ERR_NOSUCHSERVERメッセージのフォーマットを修正して、正しいスペースを含むようにしました。

具体的な変更点は以下の通りです：
- LUSERSコマンドで、パラメータが1つまたは2つ存在する場合に、適切にサーバー名がチェックされ、ERR_NOSUCHSERVERが返されるように変更。
- ERR_NOSUCHSERVERレスポンスのフォーマットにスペースを追加し、正しいプロトコルフォーマットに修正。

これらの変更により、コマンドの処理が明確になり、エラーレスポンスが適切にクライアントに伝えられるようになりました。

[notes]

close #152