### PR TITLE
[feat]: #52 LISTコマンドの実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SERVER_SRC =  src/Channel.cpp \
               src/CommandHandler_Info.cpp \
               src/CommandHandler_Join.cpp \
               src/CommandHandler_Links.cpp \
+              src/CommandHandler_List.cpp \
               src/CommandHandler_Lusers.cpp \
               src/CommandHandler_Names.cpp \
               src/CommandHandler_Nick.cpp \

--- a/inc/Channel.hpp
+++ b/inc/Channel.hpp
@@ -50,7 +50,8 @@ public:
   // user
   void addUser(User &user);
   void removeUser(User &user);
-  int userNum() const;
+  std::size_t userNum() const;
+  std::size_t getVisibleUsrNum(const User &user) const;
   std::set<User *>::const_iterator getUserBegin() const;
   std::set<User *>::const_iterator getUserEnd() const;
   bool isUserInChannel(const User &user) const;
@@ -76,7 +77,7 @@ public:
 
   // l flag
   void setUserLimit(int limit);
-  int getUserLimit() const;
+  std::size_t getUserLimit() const;
 
   // b flag
   void addBanMask(const std::string &mask);
@@ -105,13 +106,13 @@ private:
 
   unsigned int _channelModeFlag;
   std::string _channelKey;                // k flag
-  int _userLimit;                         // l flag
+  std::size_t _userLimit;                         // l flag
   std::set<std::string> _banMasks;        // b flag
   std::set<std::string> _exceptionMasks;  // e flag
   std::set<std::string> _invitationMasks; // I flag
 
   // setTopic func
-  long getCurrentUnixTimestamp();
+  std::time_t getCurrentUnixTimestamp();
 };
 
 #endif

--- a/inc/CommandHandler.hpp
+++ b/inc/CommandHandler.hpp
@@ -49,6 +49,7 @@ private:
   void PART(User &user);
   void TOPIC(User &user);
   void NAMES(User &user);
+  void LIST(User &user);
   void MOTD(User &user);
   void LUSERS(User &user);
   void VERSION(User &user);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -52,7 +52,39 @@ void Channel::removeUser(User &user) {
   user.decrementJoinedChannelCount();
 }
 
-int Channel::userNum() const { return (this->_users.size()); }
+std::size_t Channel::userNum() const { return (this->_users.size()); }
+
+std::size_t Channel::getVisibleUsrNum(const User &user) const {
+  std::size_t userNum = 0;
+
+  std::cout << 1 << std::endl;
+  if (hasChannleMode(Channel::Secret)) {
+    return (0);
+  } else if (hasChannleMode(Channel::Private)) {
+    return (0);
+  }
+  std::cout << 1 << std::endl;
+  for (std::set<User *>::const_iterator it = this->_users.begin();
+       it != this->_users.end(); it++) {
+    if ((*it)->hasMode(User::Invisible)) {
+      continue;
+    }
+    if (hasChannleMode(Channel::BanMask) && isBanned(user.getNickName())) {
+      if (!(hasChannleMode(Channel::ExceptionMask) &&
+            hasException(user.getNickName()))) {
+        continue;
+      }
+    }
+    if (hasChannleMode(Channel::InviteOnly) && !isInvited(user.getNickName())) {
+      continue;
+    } else if (hasChannleMode(Channel::InvitationMask) &&
+               !isInvited(user.getNickName())) {
+      continue;
+    }
+    userNum++;
+  }
+  return (userNum);
+}
 
 std::set<User *>::const_iterator Channel::getUserBegin() const {
   return (this->_users.begin());
@@ -134,7 +166,7 @@ const std::string &Channel::getKey() const { return (this->_channelKey); }
 // l flag
 void Channel::setUserLimit(int limit) { this->_userLimit = limit; }
 
-int Channel::getUserLimit() const { return (this->_userLimit); }
+std::size_t Channel::getUserLimit() const { return (this->_userLimit); }
 
 // b flag
 void Channel::addBanMask(const std::string &mask) {

--- a/src/CommandHandler_List.cpp
+++ b/src/CommandHandler_List.cpp
@@ -1,0 +1,43 @@
+#include "CommandHandler.hpp"
+
+void CommandHandler::LIST(User &user) {
+  std::vector<std::string> channelNames;
+
+  // error
+  if (2 <= this->_params.size()) {
+    if (this->_params.at(1) != this->_server.getServerName()) {
+      this->_server.sendReply(user.getFd(),
+                              Replies::ERR_NOSUCHSERVER(this->_params.at(1)));
+      return;
+    }
+  }
+
+  // send all Channel user
+  if (this->_params.size() == 0) {
+    for (std::map<std::string, Channel>::const_iterator it =
+             this->_server.getChannelsBegin();
+         it != this->_server.getChannelsEnd(); it++) {
+        this->_server.sendReply(
+            user.getFd(),
+            Replies::RPL_LIST(it->first, it->second.getVisibleUsrNum(user),
+                              it->second.getTopic()));
+      this->_server.sendReply(user.getFd(), Replies::RPL_LISTEND());
+    }
+    return;
+  }
+
+  // send params Channel user
+  splitChannel(channelNames);
+  for (std::size_t i = 0; i < channelNames.size(); i++) {
+    if (!this->_server.isExistChannel(channelNames.at(i))) {
+      continue;
+    }
+    Channel &channel = this->_server.getChannel(channelNames.at(i));
+      this->_server.sendReply(user.getFd(),
+                              Replies::RPL_LIST(channel.getChannelName(),
+                                                channel.getVisibleUsrNum(user),
+                                                channel.getTopic()));
+    this->_server.sendReply(user.getFd(), Replies::RPL_LISTEND());
+  }
+  return;
+}

--- a/src/CommandHandler_handleCommand.cpp
+++ b/src/CommandHandler_handleCommand.cpp
@@ -51,6 +51,8 @@ void CommandHandler::executeCommand(User &user) {
     TOPIC(user);
   } else if (this->_command == "NAMES") {
     NAMES(user);
+  } else if (this->_command == "LIST") {
+    LIST(user);
   } else if (this->_command == "MOTD") {
     MOTD(user);
   } else if (this->_command == "LUSERS") {

--- a/src/Replies.cpp
+++ b/src/Replies.cpp
@@ -113,16 +113,16 @@ const std::string Replies::RPL_LISTSTART() {
 const std::string Replies::RPL_LIST(const std::string &channel,
                                     const std::size_t &visible,
                                     const std::string &topic) {
-  std::string message;
-  message += "322 ";
-  message += " :";
-  message += channel;
-  message += " ";
-  message += visible;
-  message += " :";
-  message += topic;
-  message += "\r\n";
-  return (message);
+  std::stringstream ss;
+  ss << "322 ";
+  ss << " :";
+  ss << channel;
+  ss << " ";
+  ss << visible;
+  ss << " :";
+  ss << topic;
+  ss << "\r\n";
+  return (ss.str());
 }
 
 // 323


### PR DESCRIPTION
LISTコマンドに対応するための変更を加えました。このコマンドは、指定されたチャンネル、もしくはすべてのチャンネルとそのトピックをリストアップするために使用されます。引数が指定されない場合は、全チャンネルの情報が返されます。また、チャンネルの可視ユーザー数を計算するロジックをChannelクラスに追加しました。これは、チャンネルが秘密やプライベートモードに設定されていないか、特定のマスクによる制限を受けていない場合に、そのチャンネルにいるユーザーの数をカウントするために使用されます。

[body]
- MakefileにLISTコマンド関連のソースファイルを追加しました。
- Channelクラスにユーザー数と可視ユーザー数を取得するためのメソッドを追加しました。
- CommandHandlerクラスにLISTコマンドを処理するためのメソッドを追加しました。
- LISTコマンドの実行時に適切なリプライを返すようにRepliesクラスを更新しました。

[notes]

close #52