### PR TITLE
[refactor]: #194 fcntlの非ブロッキング設定の修正

### DIFF
--- a/src/Server_init.cpp
+++ b/src/Server_init.cpp
@@ -77,11 +77,12 @@ void Server::initSocket() {
   }
 
   // non blocking I/O
-  int flags = fcntl(this->_sfd, F_GETFL, 0);
-  if (flags == -1) {
-    throw std::runtime_error(std::strerror(errno));
-  }
-  flags |= O_NONBLOCK;
+  // int flags = fcntl(this->_sfd, F_GETFL, 0);
+  // if (flags == -1) {
+  //   throw std::runtime_error(std::strerror(errno));
+  // }
+  // flags |= O_NONBLOCK;
+  int flags = O_NONBLOCK;
   if (fcntl(this->_sfd, F_SETFL, flags) == -1) {
     throw std::runtime_error(std::strerror(errno));
   }


### PR DESCRIPTION
非ブロッキングI/O設定でのfcntlの使用方法を見直しました。以前のコードでは、`F_GETFL`フラグを使用して現在の設定を取得し、それに`O_NONBLOCK`フラグを追加していましたが、レビューに基づき直接`O_NONBLOCK`を設定するように変更しました。これにより、コードの意図がより明確になり、エラーハンドリングを簡略化できます。

[body]

- `F_GETFL`と`F_SETFL`を使用していた処理をコメントアウトし、`O_NONBLOCK`フラグを直接`F_SETFL`に設定するように変更しました。これにより、サーバーソケットの初期化時に非ブロッキングモードを確実に設定できるようになります。

[notes]

close #194