### PR TITLE
[fix]: #196 トピックコマンドのチャンネルモードフラグチェックの追加

### DIFF
--- a/src/CommandHandler_Topic.cpp
+++ b/src/CommandHandler_Topic.cpp
@@ -22,6 +22,14 @@ void CommandHandler::TOPIC(User &user) {
     return;
   }
 
+  if (channel.hasChannleMode(Channel::TopicOpOnly)) {
+    if (!channel.hasUserStatus(user, Channel::Operator)) {
+      this->_server.sendReply(user.getFd(),
+                              Replies::ERR_CHANOPRIVSNEEDED(channelName));
+      return;
+    }
+  }
+
   if (2 <= this->_params.size()) {
     setTopic(user, const_cast<Channel &>(channel));
   }


### PR DESCRIPTION
トピックコマンドを使用したとき、チャンネルのモードがトピック設定をオペレーターのみに制限している場合に、そのチェックを行う処理を追加しました。オペレーター以外のユーザーがトピックを変更しようとした際には、適切なエラーレスポンスを返します。

[notes]

close #196